### PR TITLE
Add variable-length-hash from Anemoi, add the constraint system and witness tests for Jive

### DIFF
--- a/plonk/src/plonk/constraint_system/anemoi_jive.rs
+++ b/plonk/src/plonk/constraint_system/anemoi_jive.rs
@@ -1,0 +1,360 @@
+use crate::plonk::constraint_system::{TurboCS, VarIndex};
+use noah_algebra::bls12_381::BLSScalar;
+use noah_algebra::{One, Zero};
+use noah_crypto::basic::anemoi_jive::{AnemoiJive, AnemoiJive381, AnemoiVLHTrace, JiveTrace};
+
+impl TurboCS<BLSScalar> {
+    /// Create constraints for the Anemoi permutation.
+    fn anemoi_permutation_round(
+        &mut self,
+        input_var: &([VarIndex; 2], [VarIndex; 2]),
+        output_var: &([Option<VarIndex>; 2], [Option<VarIndex>; 2]),
+        intermediate_val: &([[BLSScalar; 2]; 12], [[BLSScalar; 2]; 12]),
+        checksum: Option<BLSScalar>,
+    ) -> Option<VarIndex> {
+        let zero = BLSScalar::zero();
+        let one = BLSScalar::one();
+        let zero_var = self.zero_var();
+
+        // Allocate the intermediate values
+        // (the last line of the intermediate values is the output of the last round
+        // before the final linear layer)
+        let mut intermediate_var = ([[zero_var; 2]; 12], [[zero_var; 2]; 12]);
+
+        for r in 0..12 {
+            intermediate_var.0[r][0] = self.new_variable(intermediate_val.0[r][0]);
+            intermediate_var.0[r][1] = self.new_variable(intermediate_val.0[r][1]);
+            intermediate_var.1[r][0] = self.new_variable(intermediate_val.1[r][0]);
+            intermediate_var.1[r][1] = self.new_variable(intermediate_val.1[r][1]);
+        }
+
+        // Create the first gate --- which puts the initial value
+        self.push_add_selectors(zero, zero, zero, zero);
+        self.push_mul_selectors(zero, zero);
+        self.push_constant_selector(zero);
+        self.push_ecc_selector(zero);
+        self.push_rescue_selectors(zero, zero, zero, zero);
+        self.push_out_selector(zero);
+
+        self.wiring[0].push(input_var.0[0]); // a_0
+        self.wiring[1].push(input_var.0[1]); // b_0
+        self.wiring[2].push(input_var.1[0]); // c_0
+        self.wiring[3].push(input_var.1[1]); // d_0
+        self.wiring[4].push(intermediate_var.1[0][1]); // d_1
+        self.finish_new_gate();
+
+        self.attach_anemoi_jive_constraints_to_gate();
+
+        // Create the remaining 11 gates
+        for r in 1..12 {
+            self.push_add_selectors(zero, zero, zero, zero);
+            self.push_mul_selectors(zero, zero);
+            self.push_constant_selector(zero);
+            self.push_ecc_selector(zero);
+            self.push_rescue_selectors(zero, zero, zero, zero);
+            self.push_out_selector(zero);
+
+            self.wiring[0].push(intermediate_var.0[r - 1][0]); // a_i
+            self.wiring[1].push(intermediate_var.0[r - 1][1]); // b_i
+            self.wiring[2].push(intermediate_var.1[r - 1][0]); // c_i
+            self.wiring[3].push(intermediate_var.1[r - 1][1]); // d_i
+            self.wiring[4].push(intermediate_var.1[r][1]); // d_{i+1}
+
+            self.finish_new_gate();
+        }
+
+        if output_var.0[0].is_some() {
+            let var = output_var.0[0].unwrap();
+
+            self.push_add_selectors(
+                AnemoiJive381::MDS_MATRIX[0][0],
+                AnemoiJive381::MDS_MATRIX[0][1],
+                zero,
+                zero,
+            );
+            self.push_mul_selectors(zero, zero);
+            self.push_constant_selector(zero);
+            self.push_ecc_selector(zero);
+            self.push_rescue_selectors(zero, zero, zero, zero);
+            self.push_out_selector(zero);
+
+            self.wiring[0].push(intermediate_var.0[11][0]); // a_r
+            self.wiring[1].push(intermediate_var.0[11][1]); // b_r
+            self.wiring[2].push(intermediate_var.1[11][0]); // c_r
+            self.wiring[3].push(intermediate_var.1[11][1]); // d_r
+            self.wiring[4].push(var); // a_final
+
+            self.finish_new_gate();
+        }
+
+        if output_var.0[1].is_some() {
+            let var = output_var.0[1].unwrap();
+
+            self.push_add_selectors(
+                AnemoiJive381::MDS_MATRIX[1][0],
+                AnemoiJive381::MDS_MATRIX[1][1],
+                zero,
+                zero,
+            );
+            self.push_mul_selectors(zero, zero);
+            self.push_constant_selector(zero);
+            self.push_ecc_selector(zero);
+            self.push_rescue_selectors(zero, zero, zero, zero);
+            self.push_out_selector(zero);
+
+            self.wiring[0].push(intermediate_var.0[11][0]); // a_r
+            self.wiring[1].push(intermediate_var.0[11][1]); // b_r
+            self.wiring[2].push(intermediate_var.1[11][0]); // c_r
+            self.wiring[3].push(intermediate_var.1[11][1]); // d_r
+            self.wiring[4].push(var); // b_final
+
+            self.finish_new_gate();
+        }
+
+        if output_var.1[0].is_some() {
+            let var = output_var.1[0].unwrap();
+
+            self.push_add_selectors(
+                zero,
+                zero,
+                AnemoiJive381::MDS_MATRIX[0][1],
+                AnemoiJive381::MDS_MATRIX[0][0],
+            );
+            self.push_mul_selectors(zero, zero);
+            self.push_constant_selector(zero);
+            self.push_ecc_selector(zero);
+            self.push_rescue_selectors(zero, zero, zero, zero);
+            self.push_out_selector(zero);
+
+            self.wiring[0].push(intermediate_var.0[11][0]); // a_r
+            self.wiring[1].push(intermediate_var.0[11][1]); // b_r
+            self.wiring[2].push(intermediate_var.1[11][0]); // c_r
+            self.wiring[3].push(intermediate_var.1[11][1]); // d_r
+            self.wiring[4].push(var); // c_final
+
+            self.finish_new_gate();
+        }
+
+        if output_var.1[1].is_some() {
+            let var = output_var.1[1].unwrap();
+
+            self.push_add_selectors(
+                zero,
+                zero,
+                AnemoiJive381::MDS_MATRIX[1][1],
+                AnemoiJive381::MDS_MATRIX[1][0],
+            );
+            self.push_mul_selectors(zero, zero);
+            self.push_constant_selector(zero);
+            self.push_ecc_selector(zero);
+            self.push_rescue_selectors(zero, zero, zero, zero);
+            self.push_out_selector(zero);
+
+            self.wiring[0].push(intermediate_var.0[11][0]); // a_r
+            self.wiring[1].push(intermediate_var.0[11][1]); // b_r
+            self.wiring[2].push(intermediate_var.1[11][0]); // c_r
+            self.wiring[3].push(intermediate_var.1[11][1]); // d_r
+            self.wiring[4].push(var); // d_final
+
+            self.finish_new_gate();
+        }
+
+        if checksum.is_some() {
+            let var = self.new_variable(checksum.unwrap());
+
+            self.push_add_selectors(
+                AnemoiJive381::MDS_MATRIX[0][0] + AnemoiJive381::MDS_MATRIX[1][0],
+                AnemoiJive381::MDS_MATRIX[0][1] + AnemoiJive381::MDS_MATRIX[1][1],
+                AnemoiJive381::MDS_MATRIX[0][1] + AnemoiJive381::MDS_MATRIX[1][1],
+                AnemoiJive381::MDS_MATRIX[0][0] + AnemoiJive381::MDS_MATRIX[1][0],
+            );
+            self.push_mul_selectors(zero, zero);
+            self.push_constant_selector(zero);
+            self.push_ecc_selector(zero);
+            self.push_rescue_selectors(zero, zero, zero, zero);
+            self.push_out_selector(one);
+
+            self.wiring[0].push(intermediate_var.0[11][0]); // a_r
+            self.wiring[1].push(intermediate_var.0[11][1]); // b_r
+            self.wiring[2].push(intermediate_var.1[11][0]); // c_r
+            self.wiring[3].push(intermediate_var.1[11][1]); // d_r
+            self.wiring[4].push(var); // sum
+
+            self.finish_new_gate();
+
+            Some(var)
+        } else {
+            None
+        }
+    }
+
+    /// Create constraints for the Anemoi variable length hash function.
+    pub fn anemoi_variable_length_hash(
+        &mut self,
+        trace: &AnemoiVLHTrace<BLSScalar, 2, 12>,
+        input_var: &[VarIndex],
+        output_var: VarIndex,
+    ) {
+        assert_eq!(input_var.len(), trace.input.len());
+
+        let mut input_var = input_var.to_vec();
+        let one_var = self.one_var();
+        let zero_var = self.zero_var();
+
+        if input_var.len() % (2 * 2 - 1) != 0 || input_var.is_empty() {
+            input_var.push(one_var);
+            input_var
+                .extend_from_slice(&[zero_var].repeat(2 * 2 - 1 - (input_var.len() % (2 * 2 - 1))));
+        }
+
+        assert_eq!(input_var.len(), trace.before_permutation.len());
+
+        // after the previous step, the length of input must be multiplies of `2 * N - 1`.
+        assert_eq!(input_var.len() % (2 * 2 - 1), 0);
+
+        // initialize the internal state.
+        let chunks = input_var
+            .chunks_exact(2 * 2 - 1)
+            .map(|x| x.to_vec())
+            .collect::<Vec<Vec<VarIndex>>>();
+        let num_chunks = chunks.len();
+
+        let mut x_var = [chunks[0][0], chunks[0][1]];
+        let mut y_var = [chunks[0][2], zero_var];
+
+        if num_chunks == 1 {
+            self.anemoi_permutation_round(
+                &(x_var, y_var),
+                &([Some(output_var), None], [None, None]),
+                &trace.intermediate_values_before_constant_additions[0],
+                None,
+            );
+        } else {
+            let mut new_x_var = [
+                self.new_variable(trace.after_permutation[0].0[0]),
+                self.new_variable(trace.after_permutation[0].0[1]),
+            ];
+
+            let mut new_y_var = [
+                self.new_variable(trace.after_permutation[0].1[0]),
+                self.new_variable(trace.after_permutation[0].1[1]),
+            ];
+
+            self.anemoi_permutation_round(
+                &(x_var, y_var),
+                &(
+                    [Some(new_x_var[0]), Some(new_x_var[1])],
+                    [Some(new_y_var[0]), Some(new_y_var[1])],
+                ),
+                &trace.intermediate_values_before_constant_additions[0],
+                None,
+            );
+
+            for rr in 1..num_chunks - 1 {
+                x_var = new_x_var;
+                y_var = new_y_var;
+
+                x_var[0] += chunks[rr][0];
+                x_var[1] += chunks[rr][1];
+                y_var[0] += chunks[rr][2];
+
+                new_x_var = [
+                    self.new_variable(trace.after_permutation[rr].0[0]),
+                    self.new_variable(trace.after_permutation[rr].0[1]),
+                ];
+
+                new_y_var = [
+                    self.new_variable(trace.after_permutation[rr].1[0]),
+                    self.new_variable(trace.after_permutation[rr].1[1]),
+                ];
+
+                self.anemoi_permutation_round(
+                    &(x_var, y_var),
+                    &(
+                        [Some(new_x_var[0]), Some(new_x_var[1])],
+                        [Some(new_y_var[0]), Some(new_y_var[1])],
+                    ),
+                    &trace.intermediate_values_before_constant_additions[rr],
+                    None,
+                );
+            }
+
+            // last round
+            {
+                x_var = new_x_var;
+                y_var = new_y_var;
+
+                self.anemoi_permutation_round(
+                    &(x_var, y_var),
+                    &([Some(output_var), None], [None, None]),
+                    &trace.intermediate_values_before_constant_additions[num_chunks - 1],
+                    None,
+                );
+            }
+        }
+    }
+
+    /// Create constraints for the Jive CRH.
+    pub fn jive_crh(
+        &mut self,
+        trace: &JiveTrace<BLSScalar, 2, 12>,
+        input_var: &[VarIndex; 3],
+    ) -> VarIndex {
+        let one = BLSScalar::one();
+        let zero_var = self.zero_var();
+
+        let x_var = [input_var[0], input_var[1]];
+        let y_var = [input_var[2], zero_var];
+
+        let sum_output_val =
+            trace.final_x[0] + trace.final_x[1] + trace.final_y[0] + trace.final_y[1];
+
+        let sum_output_var = self
+            .anemoi_permutation_round(
+                &(x_var, y_var),
+                &([None, None], [None, None]),
+                &(
+                    trace.intermediate_x_before_constant_additions,
+                    trace.intermediate_y_before_constant_additions,
+                ),
+                Some(sum_output_val),
+            )
+            .unwrap();
+
+        self.linear_combine(
+            &[sum_output_var, input_var[0], input_var[1], input_var[2]],
+            one,
+            one,
+            one,
+            one,
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::plonk::constraint_system::TurboCS;
+    use noah_algebra::bls12_381::BLSScalar;
+    use noah_algebra::Zero;
+    use noah_crypto::basic::anemoi_jive::{AnemoiJive, AnemoiJive381};
+
+    #[test]
+    fn test_jive_constraint_system() {
+        let trace = AnemoiJive381::eval_jive_with_trace(
+            &[BLSScalar::from(1u64), BLSScalar::from(2u64)],
+            &[BLSScalar::from(3u64), BLSScalar::zero()],
+        );
+
+        let mut cs = TurboCS::new();
+        cs.load_anemoi_jive_parameters::<AnemoiJive381>();
+
+        let one = cs.new_variable(BLSScalar::from(1u64));
+        let two = cs.new_variable(BLSScalar::from(2u64));
+        let three = cs.new_variable(BLSScalar::from(3u64));
+
+        let _ = cs.jive_crh(&trace, &[one, two, three]);
+
+        let witness = cs.get_and_clear_witness();
+        cs.verify_witness(&witness, &[]).unwrap();
+    }
+}

--- a/plonk/src/plonk/constraint_system/mod.rs
+++ b/plonk/src/plonk/constraint_system/mod.rs
@@ -12,6 +12,9 @@ pub mod turbo;
 /// Module for ECC.
 pub mod ecc;
 
+/// Module for the Anemoi-Jive hash function.
+pub mod anemoi_jive;
+
 /// Default used constraint system.
 #[doc(hidden)]
 pub use turbo::TurboCS;

--- a/plonk/src/plonk/constraint_system/turbo.rs
+++ b/plonk/src/plonk/constraint_system/turbo.rs
@@ -8,7 +8,6 @@ use noah_algebra::prelude::*;
 
 #[cfg(feature = "debug")]
 use std::collections::HashMap;
-
 use noah_crypto::basic::anemoi_jive::AnemoiJive;
 
 /// The wires number of a gate in Turbo CS.

--- a/plonk/src/plonk/constraint_system/turbo.rs
+++ b/plonk/src/plonk/constraint_system/turbo.rs
@@ -6,9 +6,9 @@ use super::{ConstraintSystem, CsIndex, VarIndex};
 use crate::plonk::errors::PlonkError;
 use noah_algebra::prelude::*;
 
+use noah_crypto::basic::anemoi_jive::AnemoiJive;
 #[cfg(feature = "debug")]
 use std::collections::HashMap;
-use noah_crypto::basic::anemoi_jive::AnemoiJive;
 
 /// The wires number of a gate in Turbo CS.
 pub const N_WIRES_PER_GATE: usize = 5;

--- a/plonk/src/plonk/constraint_system/turbo.rs
+++ b/plonk/src/plonk/constraint_system/turbo.rs
@@ -283,12 +283,12 @@ impl<F: Scalar> TurboCS<F> {
     }
 
     /// 0-index is Zero
-    pub fn zero_var(&mut self) -> VarIndex {
+    pub fn zero_var(&self) -> VarIndex {
         0
     }
 
     /// 1-index is One
-    pub fn one_var(&mut self) -> VarIndex {
+    pub fn one_var(&self) -> VarIndex {
         1
     }
 
@@ -844,6 +844,7 @@ impl<F: Scalar> TurboCS<F> {
         {
             return Err(eg!("wrong number of online variables"));
         }
+
         for cs_index in 0..self.size() {
             let mut public_online = F::zero();
             // check if the constraint constrains a public variable
@@ -881,6 +882,118 @@ impl<F: Scalar> TurboCS<F> {
                     "cs index {}: wire_vals = ({:?}), sel_vals = ({:?})",
                     cs_index, wire_vals, sel_vals
                 )));
+            }
+
+            if self.boolean_constraint_indices.contains(&cs_index) {
+                if !w1_value.is_zero() && !w1_value.is_one() {
+                    return Err(eg!(format!(
+                        "cs index {}: the first wire {:?} is not one or zero",
+                        cs_index, w1_value
+                    )));
+                }
+
+                if !w2_value.is_zero() && !w2_value.is_one() {
+                    return Err(eg!(format!(
+                        "cs index {}: the second wire {:?} is not one or zero",
+                        cs_index, w2_value
+                    )));
+                }
+
+                if !w3_value.is_zero() && !w3_value.is_one() {
+                    return Err(eg!(format!(
+                        "cs index {}: the third wire {:?} is not one or zero",
+                        cs_index, w3_value
+                    )));
+                }
+            }
+
+            if !self.anemoi_constraints_indices.is_empty() {
+                assert!(!self.anemoi_generator.is_zero());
+            }
+
+            for cs_index in self.anemoi_constraints_indices.iter() {
+                for r in 0..12 {
+                    let a_i = witness[self.get_witness_index(0, cs_index + r)];
+                    let b_i = witness[self.get_witness_index(1, cs_index + r)];
+                    let c_i = witness[self.get_witness_index(2, cs_index + r)];
+                    let d_i = witness[self.get_witness_index(3, cs_index + r)];
+                    let o_i = witness[self.get_witness_index(4, cs_index + r)];
+
+                    let a_i_next = witness[self.get_witness_index(0, cs_index + 1 + r)];
+                    let b_i_next = witness[self.get_witness_index(1, cs_index + 1 + r)];
+                    let c_i_next = witness[self.get_witness_index(2, cs_index + 1 + r)];
+                    let d_i_next = witness[self.get_witness_index(3, cs_index + 1 + r)];
+
+                    if o_i != d_i_next {
+                        return Err(eg!(format!(
+                        "cs index {} round {}: the output wire {:?} does not equal to the fourth wire {:?} in the next constraint",
+                            cs_index,
+                            r,
+                            o_i,
+                            d_i_next
+                        )));
+                    }
+
+                    let prk_i_a = self.anemoi_preprocessed_round_keys_x[r][0].clone();
+                    let prk_i_b = self.anemoi_preprocessed_round_keys_x[r][1].clone();
+                    let prk_i_c = self.anemoi_preprocessed_round_keys_y[r][0].clone();
+                    let prk_i_d = self.anemoi_preprocessed_round_keys_y[r][1].clone();
+
+                    let g = self.anemoi_generator;
+                    let g2 = g.square().add(F::one());
+
+                    // equation 1
+                    let left = (d_i + g * c_i + prk_i_c - &c_i_next).pow(&[5u64])
+                        + g * (d_i + g * c_i + prk_i_c).square();
+                    let right = a_i + g * b_i + prk_i_a;
+                    if left != right {
+                        return Err(eg!(format!(
+                            "cs index {} round {}: the first equation does not equal: {:?} != {:?}",
+                            cs_index, r, left, right
+                        )));
+                    }
+
+                    // equation 2
+                    let left = (g * d_i + g2 * c_i + prk_i_d - &d_i_next).pow(&[5u64])
+                        + g * (g * d_i + g2 * c_i + prk_i_d).square();
+                    let right = g * a_i + g2 * b_i + prk_i_b;
+                    if left != right {
+                        return Err(eg!(format!(
+                        "cs index {} round {}: the second equation does not equal: {:?} != {:?}",
+                            cs_index,
+                            r,
+                            left,
+                            right
+                        )));
+                    }
+
+                    // equation 3
+                    let left = (d_i + g * c_i + prk_i_c - &c_i_next).pow(&[5u64])
+                        + g * c_i_next.square()
+                        + self.anemoi_generator_inv;
+                    let right = a_i_next;
+                    if left != right {
+                        return Err(eg!(format!(
+                            "cs index {} round {}: the third equation does not equal: {:?} != {:?}",
+                            cs_index, r, left, right
+                        )));
+                    }
+
+                    // equation 4
+                    let left = (g * d_i + g2 * c_i + prk_i_d - &d_i_next).pow(&[5u64])
+                        + g * d_i_next.square()
+                        + self.anemoi_generator_inv;
+                    let right = b_i_next;
+                    if left != right {
+                        return Err(eg!(format!(
+                        "cs index {} round {}: the fourth equation does not equal: {:?} != {:?}",
+                            cs_index,
+                            r,
+                            left,
+                            right
+                        )));
+                    }
+                }
             }
         }
         Ok(())

--- a/plonk/src/plonk/constraint_system/turbo.rs
+++ b/plonk/src/plonk/constraint_system/turbo.rs
@@ -885,13 +885,6 @@ impl<F: Scalar> TurboCS<F> {
             }
 
             if self.boolean_constraint_indices.contains(&cs_index) {
-                if !w1_value.is_zero() && !w1_value.is_one() {
-                    return Err(eg!(format!(
-                        "cs index {}: the first wire {:?} is not one or zero",
-                        cs_index, w1_value
-                    )));
-                }
-
                 if !w2_value.is_zero() && !w2_value.is_one() {
                     return Err(eg!(format!(
                         "cs index {}: the second wire {:?} is not one or zero",
@@ -903,6 +896,13 @@ impl<F: Scalar> TurboCS<F> {
                     return Err(eg!(format!(
                         "cs index {}: the third wire {:?} is not one or zero",
                         cs_index, w3_value
+                    )));
+                }
+
+                if !w4_value.is_zero() && !w4_value.is_one() {
+                    return Err(eg!(format!(
+                        "cs index {}: the fourth wire {:?} is not one or zero",
+                        cs_index, w4_value
                     )));
                 }
             }


### PR DESCRIPTION
* **The major changes of this PR**

This is the third PR adding Anemoi/Jive into the Noah library. The next steps are (1) to add a constraint system and witness tests for Anemoi, (2) to add a salt value for additional protection for Jive, (3) to add the equation into TurboPlonk and perform TurboPlonk end-to-end tests, (4) to gradually replace the Rescue commitment with Anemoi hash function, (5) to replace the Rescue CRH with Jive CRH, and (6) to remove Rescue from Noah. 

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

