### PR TITLE
Allow the aes-gcm new version

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -31,7 +31,7 @@ crate-type = ['rlib']
 
 [dependencies]
 aes = '0.8.1'
-aes-gcm = '=0.10.0-pre'
+aes-gcm = '0.10.1'
 bincode = '1.3.1'
 bulletproofs = "2.0"
 digest = '0.10'

--- a/api/src/anon_xfr/keys.rs
+++ b/api/src/anon_xfr/keys.rs
@@ -1,4 +1,4 @@
-use aes_gcm::{aead::Aead, NewAead};
+use aes_gcm::{aead::Aead, KeyInit};
 use digest::{generic_array::GenericArray, Digest};
 use noah_algebra::secp256k1::{SECP256K1Scalar, SECP256K1G1, SECP256K1_SCALAR_LEN};
 use noah_algebra::{bls12_381::BLSScalar, prelude::*};


### PR DESCRIPTION
* **The major changes of this PR**

Previously we are using =v0.10.0-pre1 of aes-gcm due to compatibility issues. Now, as the newer version is released, this issue can be handled gracefully. This PR does so.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

