### PR TITLE
Tag ark-bulletproofs

### DIFF
--- a/algebra/Cargo.toml
+++ b/algebra/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ['rlib']
 
 [dependencies]
 base64 = "0.13"
-bulletproofs = { git = "https://github.com/FindoraNetwork/bp", tag = "v1.0.2-f"  }
+bulletproofs = { git = "https://github.com/FindoraNetwork/bulletproofs", tag = "v1.0.2-f"  }
 digest = '0.10'
 itertools = '0.10.0'
 ruc = '1.0'
@@ -77,8 +77,10 @@ version = "0.2"
 [dependencies.num-integer]
 version = "0.1"
 
-[dependencies.ark-bulletproofs-secq256k1]
-git = "https://github.com/FindoraNetwork/ark-bulletproofs-secq256k1"
+[dependencies.ark-bulletproofs]
+git = "https://github.com/FindoraNetwork/ark-bulletproofs"
+tag = "v2.0.0-f"
+package = "ark-bulletproofs-secq256k1"
 default-features = false
 features = ['yoloproofs']
 
@@ -95,7 +97,7 @@ std = [
     'ark-std/std',
     'ark-ff/std',
     'ark-serialize/std',
-    'ark-bulletproofs-secq256k1/std'
+    'ark-bulletproofs/std'
 ]
 alloc = ['curve25519-dalek/alloc']
 nightly = ['curve25519-dalek/nightly']
@@ -107,7 +109,7 @@ parallel = [
     'ark-std/parallel',
     'ark-ec/parallel',
     'ark-ff/parallel',
-    'ark-bulletproofs-secq256k1/parallel'
+    'ark-bulletproofs/parallel'
 ]
 asm = ['ark-ff/asm']
 print-trace = ['ark-std/print-trace']

--- a/algebra/src/secp256k1.rs
+++ b/algebra/src/secp256k1.rs
@@ -1,7 +1,7 @@
 use crate::errors::AlgebraError;
 use crate::prelude::*;
 use crate::secq256k1::SECQ256K1Scalar;
-use ark_bulletproofs_secq256k1::curve::secp256k1::{Fr, FrParameters, G1Affine, G1Projective};
+use ark_bulletproofs::curve::secp256k1::{Fr, FrParameters, G1Affine, G1Projective};
 use ark_ec::short_weierstrass_jacobian::GroupProjective;
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{BigInteger, BigInteger320, FftField, FftParameters, Field, FpParameters, PrimeField};
@@ -22,7 +22,7 @@ use wasm_bindgen::prelude::*;
 /// The number of bytes for a scalar value over secp256k1
 pub const SECP256K1_SCALAR_LEN: usize = 32;
 
-/// The wrapped struct for [`ark_bulletproofs_secq256k1::curve::secp256k1::Fr`](https://github.com/FindoraNetwork/ark-bulletproofs-secq256k1/blob/main/src/curve/secp256k1/fr.rs)
+/// The wrapped struct for [`ark_bulletproofs::curve::secp256k1::Fr`](https://github.com/FindoraNetwork/ark-bulletproofs/blob/main/src/curve/secp256k1/fr.rs)
 #[wasm_bindgen]
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 pub struct SECP256K1Scalar(pub(crate) Fr);
@@ -49,7 +49,7 @@ impl SECP256K1Scalar {
     }
 }
 
-/// The wrapped struct for [`ark_bulletproofs_secq256k1::curve::secp256k1::G1Projective`](https://github.com/FindoraNetwork/ark-bulletproofs-secq256k1/blob/main/src/curve/secp256k1/g1.rs)
+/// The wrapped struct for [`ark_bulletproofs::curve::secp256k1::G1Projective`](https://github.com/FindoraNetwork/ark-bulletproofs/blob/main/src/curve/secp256k1/g1.rs)
 #[wasm_bindgen]
 #[derive(Copy, Default, Clone, PartialEq, Eq, Hash)]
 pub struct SECP256K1G1(pub(crate) G1Projective);
@@ -222,7 +222,7 @@ impl Scalar for SECP256K1Scalar {
 
     #[inline]
     fn capacity() -> usize {
-        ark_bulletproofs_secq256k1::curve::secp256k1::FrParameters::CAPACITY as usize
+        ark_bulletproofs::curve::secp256k1::FrParameters::CAPACITY as usize
     }
 
     #[inline]
@@ -511,7 +511,7 @@ mod secp256k1_groups_test {
         secp256k1::{SECP256K1Scalar, SECP256K1G1},
         traits::group_tests::{test_scalar_operations, test_scalar_serialization},
     };
-    use ark_bulletproofs_secq256k1::curve::secp256k1::G1Affine;
+    use ark_bulletproofs::curve::secp256k1::G1Affine;
     use ark_ec::ProjectiveCurve;
 
     #[test]

--- a/algebra/src/secq256k1.rs
+++ b/algebra/src/secq256k1.rs
@@ -1,6 +1,6 @@
 use crate::errors::AlgebraError;
 use crate::prelude::*;
-use ark_bulletproofs_secq256k1::curve::secq256k1::{Fr, FrParameters, G1Affine, G1Projective};
+use ark_bulletproofs::curve::secq256k1::{Fr, FrParameters, G1Affine, G1Projective};
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{BigInteger, BigInteger320, FftField, FftParameters, Field, FpParameters, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -20,7 +20,7 @@ use wasm_bindgen::prelude::*;
 /// The number of bytes for a scalar value over the secq256k1 curve
 pub const SECQ256K1_SCALAR_LEN: usize = 32;
 
-/// The wrapped struct for [`ark_bulletproofs_secq256k1::curve::secq256k1::Fr`](https://github.com/FindoraNetwork/ark-bulletproofs-secq256k1/blob/main/src/curve/secq256k1/fr.rs)
+/// The wrapped struct for [`ark_bulletproofs::curve::secq256k1::Fr`](https://github.com/FindoraNetwork/ark-bulletproofs/blob/main/src/curve/secq256k1/fr.rs)
 #[wasm_bindgen]
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 pub struct SECQ256K1Scalar(pub(crate) Fr);
@@ -34,7 +34,7 @@ impl Debug for SECQ256K1Scalar {
     }
 }
 
-/// The wrapped struct for [`ark_bulletproofs_secq256k1::curve::secq256k1::G1Projective`](https://github.com/FindoraNetwork/ark-bulletproofs-secq256k1/blob/main/src/curve/secq256k1/g1.rs)
+/// The wrapped struct for [`ark_bulletproofs::curve::secq256k1::G1Projective`](https://github.com/FindoraNetwork/ark-bulletproofs/blob/main/src/curve/secq256k1/g1.rs)
 #[wasm_bindgen]
 #[derive(Copy, Default, Clone, PartialEq, Eq)]
 pub struct SECQ256K1G1(pub(crate) G1Projective);
@@ -198,7 +198,7 @@ impl Scalar for SECQ256K1Scalar {
 
     #[inline]
     fn capacity() -> usize {
-        ark_bulletproofs_secq256k1::curve::secq256k1::FrParameters::CAPACITY as usize
+        ark_bulletproofs::curve::secq256k1::FrParameters::CAPACITY as usize
     }
 
     #[inline]
@@ -478,7 +478,7 @@ mod secq256k1_groups_test {
         secq256k1::{SECQ256K1Scalar, SECQ256K1G1},
         traits::group_tests::{test_scalar_operations, test_scalar_serialization},
     };
-    use ark_bulletproofs_secq256k1::curve::secq256k1::G1Affine;
+    use ark_bulletproofs::curve::secq256k1::G1Affine;
     use ark_ec::ProjectiveCurve;
 
     #[test]

--- a/algebra/src/serialization.rs
+++ b/algebra/src/serialization.rs
@@ -127,14 +127,14 @@ impl NoahFromToBytes for bulletproofs::r1cs::R1CSProof {
     }
 }
 
-impl NoahFromToBytes for ark_bulletproofs_secq256k1::r1cs::R1CSProof {
+impl NoahFromToBytes for ark_bulletproofs::r1cs::R1CSProof {
     fn noah_to_bytes(&self) -> Vec<u8> {
         let mut cursor = Cursor::new(Vec::new());
         self.serialize(&mut cursor).unwrap();
         cursor.into_inner()
     }
-    fn noah_from_bytes(bytes: &[u8]) -> Result<ark_bulletproofs_secq256k1::r1cs::R1CSProof> {
-        ark_bulletproofs_secq256k1::r1cs::R1CSProof::deserialize(bytes)
+    fn noah_from_bytes(bytes: &[u8]) -> Result<ark_bulletproofs::r1cs::R1CSProof> {
+        ark_bulletproofs::r1cs::R1CSProof::deserialize(bytes)
             .map_err(|_| eg!(NoahError::DeserializationError))
     }
 }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -38,7 +38,7 @@ crate-type = ['rlib']
 aes = '0.8.1'
 aes-gcm = '0.10.1'
 bincode = '1.3.1'
-bulletproofs = { git = "https://github.com/FindoraNetwork/bp", tag = "v1.0.2-f"  }
+bulletproofs = { git = "https://github.com/FindoraNetwork/bulletproofs", tag = "v1.0.2-f"  }
 digest = '0.10'
 ed25519-dalek = { git = "https://github.com/FindoraNetwork/ed25519-dalek", tag = "v1.0.1-f" }
 lazy_static = "1.4.0"
@@ -127,8 +127,10 @@ tag = 'v0.2.2'
 git = 'https://github.com/FindoraNetwork/storage.git'
 tag = 'v0.2.2'
 
-[dependencies.ark-bulletproofs-secq256k1]
-git = "https://github.com/FindoraNetwork/ark-bulletproofs-secq256k1"
+[dependencies.ark-bulletproofs]
+git = "https://github.com/FindoraNetwork/ark-bulletproofs"
+tag = "v2.0.0-f"
+package = "ark-bulletproofs-secq256k1"
 default-features = false
 features = ["yoloproofs"]
 
@@ -138,7 +140,7 @@ default = [
     'u64_backend',
 ]
 debug = [ 'noah-plonk/debug' ]
-std = ['curve25519-dalek/std', 'bulletproofs/std', 'ark-bulletproofs-secq256k1/std', 'ark-std/std']
+std = ['curve25519-dalek/std', 'bulletproofs/std', 'ark-bulletproofs/std', 'ark-std/std']
 alloc = ['curve25519-dalek/alloc']
 nightly = [
     'curve25519-dalek/nightly',

--- a/api/src/anon_xfr/address_folding.rs
+++ b/api/src/anon_xfr/address_folding.rs
@@ -100,7 +100,7 @@ pub fn create_address_folding<R: CryptoRng + RngCore, D: Digest<OutputSize = U64
     keypair: &AXfrKeyPair,
 ) -> Result<(AXfrAddressFoldingInstance, AXfrAddressFoldingWitness)> {
     let pc_gens = PedersenCommitmentSecq256k1::default();
-    let bp_gens = ark_bulletproofs_secq256k1::BulletproofGens::load().unwrap();
+    let bp_gens = ark_bulletproofs::BulletproofGens::load().unwrap();
 
     let public_key = keypair.get_public_key();
     let secret_key = keypair.get_secret_key();
@@ -153,7 +153,7 @@ pub fn verify_address_folding<D: Digest<OutputSize = U64> + Default>(
     instance: &AXfrAddressFoldingInstance,
 ) -> Result<(SECQ256K1Scalar, SECQ256K1Scalar)> {
     let pc_gens = PedersenCommitmentSecq256k1::default();
-    let bp_gens = ark_bulletproofs_secq256k1::BulletproofGens::load().unwrap();
+    let bp_gens = ark_bulletproofs::BulletproofGens::load().unwrap();
 
     // important: address folding relies significantly on the Fiat-Shamir transform.
     transcript.append_message(b"hash", hash.finalize().as_slice());

--- a/api/src/gen-params.rs
+++ b/api/src/gen-params.rs
@@ -5,7 +5,7 @@
     allow(unused)
 )]
 
-use ark_bulletproofs_secq256k1::BulletproofGens as BulletproofGensOverSecq256k1;
+use ark_bulletproofs::BulletproofGens as BulletproofGensOverSecq256k1;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use bulletproofs::BulletproofGens;
 use noah::setup::{

--- a/api/src/setup.rs
+++ b/api/src/setup.rs
@@ -17,7 +17,7 @@ use crate::parameters::{
     BAR_TO_ABAR_VERIFIER_PARAMS, BULLETPROOF_CURVE25519_URS, BULLETPROOF_SECQ256K1_URS,
     LAGRANGE_BASES, SRS, VERIFIER_COMMON_PARAMS, VERIFIER_SPECIFIC_PARAMS,
 };
-use ark_bulletproofs_secq256k1::BulletproofGens as BulletproofGensOverSecq256k1;
+use ark_bulletproofs::BulletproofGens as BulletproofGensOverSecq256k1;
 use ark_serialize::CanonicalDeserialize;
 use bulletproofs::BulletproofGens;
 use noah_algebra::ristretto::RistrettoPoint;

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ['rlib']
 
 [dependencies]
 aes = '0.8.1'
-bulletproofs = { git = "https://github.com/FindoraNetwork/bp", tag = "v1.0.2-f"  }
+bulletproofs = { git = "https://github.com/FindoraNetwork/bulletproofs", tag = "v1.0.2-f"  }
 ctr = '0.9.1'
 digest = '0.10'
 ed25519-dalek = { git = "https://github.com/FindoraNetwork/ed25519-dalek", tag = "v1.0.1-f" }
@@ -65,8 +65,10 @@ version = '^0.3.0'
 default-features = false
 features = ['asm']
 
-[dependencies.ark-bulletproofs-secq256k1]
-git = "https://github.com/FindoraNetwork/ark-bulletproofs-secq256k1"
+[dependencies.ark-bulletproofs]
+git = "https://github.com/FindoraNetwork/ark-bulletproofs"
+tag = "v2.0.0-f"
+package = "ark-bulletproofs-secq256k1"
 default-features = false
 features = ["yoloproofs"]
 
@@ -86,7 +88,7 @@ default = [
     'std',
     'u64_backend',
 ]
-std = ['curve25519-dalek/std', 'ark-bulletproofs-secq256k1/std', 'ark-std/std']
+std = ['curve25519-dalek/std', 'ark-bulletproofs/std', 'ark-std/std']
 alloc = ['curve25519-dalek/alloc']
 nightly = [
     'curve25519-dalek/nightly',

--- a/crypto/src/basic/pedersen_comm.rs
+++ b/crypto/src/basic/pedersen_comm.rs
@@ -73,7 +73,7 @@ pub struct PedersenCommitmentSecq256k1 {
 
 impl Default for PedersenCommitmentSecq256k1 {
     fn default() -> Self {
-        let pc_gens = ark_bulletproofs_secq256k1::PedersenGens::default();
+        let pc_gens = ark_bulletproofs::PedersenGens::default();
         Self {
             B: SECQ256K1G1::from_raw(pc_gens.B),
             B_blinding: SECQ256K1G1::from_raw(pc_gens.B_blinding),
@@ -95,9 +95,9 @@ impl PedersenCommitment<SECQ256K1G1> for PedersenCommitmentSecq256k1 {
     }
 }
 
-impl From<&PedersenCommitmentSecq256k1> for ark_bulletproofs_secq256k1::PedersenGens {
+impl From<&PedersenCommitmentSecq256k1> for ark_bulletproofs::PedersenGens {
     fn from(rp: &PedersenCommitmentSecq256k1) -> Self {
-        ark_bulletproofs_secq256k1::PedersenGens {
+        ark_bulletproofs::PedersenGens {
             B: rp.B.get_raw(),
             B_blinding: rp.B_blinding.get_raw(),
         }

--- a/crypto/src/bulletproofs/scalar_mul.rs
+++ b/crypto/src/bulletproofs/scalar_mul.rs
@@ -1,8 +1,8 @@
 //! Module for the Bulletproof scalar mul proof scheme
 
 use crate::basic::pedersen_comm::PedersenCommitmentSecq256k1;
-use ark_bulletproofs_secq256k1::BulletproofGens;
-use ark_bulletproofs_secq256k1::{
+use ark_bulletproofs::BulletproofGens;
+use ark_bulletproofs::{
     curve::secp256k1::{Fq, FrParameters, G1Affine},
     curve::secq256k1::G1Affine as G1AffineBig,
     r1cs::{
@@ -269,7 +269,7 @@ impl ScalarMulProof {
         transcript.append_message(b"dom-sep", b"ScalarMulProof");
 
         // 3. Initialize the prover.
-        let pc_gens_for_prover = ark_bulletproofs_secq256k1::PedersenGens::from(&pc_gens);
+        let pc_gens_for_prover = ark_bulletproofs::PedersenGens::from(&pc_gens);
         let mut prover = Prover::new(&pc_gens_for_prover, transcript);
 
         // 4. Allocate `public_key`.
@@ -353,7 +353,7 @@ impl ScalarMulProof {
         )
         .c(d!(NoahError::R1CSProofError))?;
 
-        let pc_gens_for_verifier = ark_bulletproofs_secq256k1::PedersenGens::from(&pc_gens);
+        let pc_gens_for_verifier = ark_bulletproofs::PedersenGens::from(&pc_gens);
         verifier
             .verify(&self.0, &pc_gens_for_verifier, &bp_gens)
             .c(d!(NoahError::R1CSProofError))?;
@@ -363,7 +363,7 @@ impl ScalarMulProof {
 
 #[test]
 fn scalar_mul_test() {
-    use ark_bulletproofs_secq256k1::curve::secp256k1::Fr;
+    use ark_bulletproofs::curve::secp256k1::Fr;
 
     let bp_gens = BulletproofGens::new(2048, 1);
 

--- a/smoke-tests/Cargo.toml
+++ b/smoke-tests/Cargo.toml
@@ -12,7 +12,7 @@ path = '../api'
 aes = '0.8.1'
 aes-gcm = '0.10.1'
 bincode = '1.3.1'
-bulletproofs = { git = "https://github.com/FindoraNetwork/bp", tag = "v1.0.2-f"  }
+bulletproofs = { git = "https://github.com/FindoraNetwork/bulletproofs", tag = "v1.0.2-f"  }
 digest = '0.10'
 ed25519-dalek = { git = "https://github.com/FindoraNetwork/ed25519-dalek", tag = "v1.0.1-f" }
 lazy_static = "1.4.0"
@@ -101,8 +101,10 @@ tag = 'v0.2.2'
 git = 'https://github.com/FindoraNetwork/storage.git'
 tag = 'v0.2.2'
 
-[dependencies.ark-bulletproofs-secq256k1]
-git = "https://github.com/FindoraNetwork/ark-bulletproofs-secq256k1"
+[dependencies.ark-bulletproofs]
+git = "https://github.com/FindoraNetwork/ark-bulletproofs"
+tag = "v2.0.0-f"
+package = "ark-bulletproofs-secq256k1"
 default-features = false
 features = ["yoloproofs"]
 
@@ -111,7 +113,7 @@ default = [
     'std'
 ]
 debug = [ 'noah-plonk/debug', 'noah/debug' ]
-std = ['curve25519-dalek/std', 'noah/std', 'bulletproofs/std', 'ark-bulletproofs-secq256k1/std', 'ark-std/std']
+std = ['curve25519-dalek/std', 'noah/std', 'bulletproofs/std', 'ark-bulletproofs/std', 'ark-std/std']
 parallel = [
     'default',
     'rayon',


### PR DESCRIPTION
* **The major changes of this PR**

We have tagged many repos, but the one that is left is ark-bulletproofs (previously, ark-bulletproofs-secq256k1). This one adds the tag.

The platform library will be updated with a new version as well.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

