### PR TITLE
Add back getrandom dev-dependency in smoke-tests

### DIFF
--- a/smoke-tests/Cargo.toml
+++ b/smoke-tests/Cargo.toml
@@ -98,6 +98,7 @@ serde_json = '1.0'
 typenum = '1.11.2'
 parking_lot = '0.12'
 wasm-bindgen-test = "0.3.34"
+getrandom = { version = "0.2.8", features = ['js'] }
 
 [dev-dependencies.noah-accumulators]
 path = '../accumulators'


### PR DESCRIPTION
* **The major changes of this PR**

The previous PR (#250) has a leftover change that removes getrandom's dev-dependency (with features "js"), which causes an issue. This PR fixes so.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

