### PR TITLE
Snarkify recommends explicitly removing zeroes before calling fastMSM

### DIFF
--- a/algebra/src/bls12_381/g1.rs
+++ b/algebra/src/bls12_381/g1.rs
@@ -122,8 +122,8 @@ impl Group for BLSG1 {
 
     #[inline]
     fn from_hash<D>(hash: D) -> Self
-        where
-            D: Digest<OutputSize=U64> + Default,
+    where
+        D: Digest<OutputSize = U64> + Default,
     {
         let mut prng = derive_prng_from_hash::<D>(hash);
         Self(G1Projective::rand(&mut prng))

--- a/algebra/src/bls12_381/g1.rs
+++ b/algebra/src/bls12_381/g1.rs
@@ -153,9 +153,14 @@ impl Group for BLSG1 {
                 .clone()
                 .expect("FastMSM WASM not initialized")
                 .exports();
-            let scalars_vec: Vec<_> = scalars.iter().map(|r| r.0).collect();
+
+            let scalars_and_points_iter = scalars.iter().zip(points).filter(|(s, _)| s.is_zero());
+
+            let scalars_vec: Vec<_> = scalars_and_points_iter.clone().map(|(r, _)| r.0).collect();
             let points_vec = G1Projective::normalize_batch(
-                &points.iter().map(|r| r.0).collect::<Vec<G1Projective>>(),
+                &scalars_and_points_iter
+                    .map(|(_, r)| r.0)
+                    .collect::<Vec<G1Projective>>(),
             );
 
             let size = scalars_vec.len();

--- a/algebra/src/bls12_381/g1.rs
+++ b/algebra/src/bls12_381/g1.rs
@@ -122,8 +122,8 @@ impl Group for BLSG1 {
 
     #[inline]
     fn from_hash<D>(hash: D) -> Self
-    where
-        D: Digest<OutputSize = U64> + Default,
+        where
+            D: Digest<OutputSize=U64> + Default,
     {
         let mut prng = derive_prng_from_hash::<D>(hash);
         Self(G1Projective::rand(&mut prng))
@@ -154,7 +154,7 @@ impl Group for BLSG1 {
                 .expect("FastMSM WASM not initialized")
                 .exports();
 
-            let scalars_and_points_iter = scalars.iter().zip(points).filter(|(s, _)| s.is_zero());
+            let scalars_and_points_iter = scalars.iter().zip(points).filter(|(s, _)| !s.is_zero());
 
             let scalars_vec: Vec<_> = scalars_and_points_iter.clone().map(|(r, _)| r.0).collect();
             let points_vec = G1Projective::normalize_batch(


### PR DESCRIPTION
* **The major changes of this PR**

Snarkify recommends that zeroes scalars as well as their associated points should better be removed before calling fastMSM.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

