### PR TITLE
Remove customized heights for gen_abar_to_ar and gen_abar_to_bar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   style:
-    name: Check Style
+    name: Check style
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,29 @@ jobs:
       - name: fmt
         run: cargo fmt --all -- --check
 
+  check-benches:
+    name: Check benchmarks
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -Dwarnings
+      CARGO_TERM_COLOR: always
+    strategy:
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-benches-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check
+        run: |
+          cargo bench --no-run
+
   test-accumulators:
     name: Test (accumulators/)
     runs-on: ubuntu-latest

--- a/api/benches/anon_xfr.rs
+++ b/api/benches/anon_xfr.rs
@@ -164,7 +164,7 @@ fn abar_to_abar(
 fn abar_to_ar(c: &mut Criterion) {
     let mut prng = test_rng();
     let address_format = SECP256K1;
-    let params = ProverParams::gen_abar_to_ar(TREE_DEPTH, address_format).unwrap();
+    let params = ProverParams::gen_abar_to_ar(address_format).unwrap();
     let verify_params = VerifierParams::get_abar_to_ar(address_format).unwrap();
 
     let sender = KeyPair::sample(&mut prng, address_format);

--- a/api/benches/anon_xfr.rs
+++ b/api/benches/anon_xfr.rs
@@ -226,7 +226,7 @@ fn abar_to_ar(c: &mut Criterion) {
 fn abar_to_bar(c: &mut Criterion) {
     let mut prng = test_rng();
     let address_format = SECP256K1;
-    let params = ProverParams::gen_abar_to_bar(TREE_DEPTH, address_format).unwrap();
+    let params = ProverParams::gen_abar_to_bar(address_format).unwrap();
     let verify_params = VerifierParams::get_abar_to_bar(address_format).unwrap();
 
     let sender = KeyPair::sample(&mut prng, address_format);

--- a/api/benches/anon_xfr.rs
+++ b/api/benches/anon_xfr.rs
@@ -14,7 +14,7 @@ use noah::{
             AnonAssetRecord, MTLeafInfo, MTNode, MTPath, OpenAnonAssetRecord,
             OpenAnonAssetRecordBuilder,
         },
-        FEE_TYPE, TREE_DEPTH,
+        FEE_TYPE,
     },
     keys::KeyPair,
     xfr::{

--- a/api/src/parameters/params.rs
+++ b/api/src/parameters/params.rs
@@ -236,7 +236,6 @@ impl ProverParams {
 
     /// Obtain the parameters for anonymous to confidential.
     pub fn gen_abar_to_bar(
-        tree_depth: usize,
         address_format: AddressFormat,
     ) -> Result<ProverParams> {
         let label = match address_format {
@@ -287,7 +286,7 @@ impl ProverParams {
             uid: 0,
             amount: 0,
             asset_type: bls_zero,
-            path: MTPath::new(vec![node.clone(); tree_depth]),
+            path: MTPath::new(vec![node.clone(); TREE_DEPTH]),
             blind: bls_zero,
         };
 
@@ -320,14 +319,10 @@ impl ProverParams {
         let pcs = load_srs_params(cs_size)?;
         let lagrange_pcs = load_lagrange_params(cs_size);
 
-        let verifier_params = if tree_depth == TREE_DEPTH {
-            match VerifierParams::load_abar_to_bar(address_format).ok() {
+        let verifier_params = match VerifierParams::load_abar_to_bar(address_format).ok() {
                 Some(v) => Some(v.verifier_params),
                 None => None,
-            }
-        } else {
-            None
-        };
+            };
 
         let prover_params =
             indexer_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref(), verifier_params).unwrap();
@@ -390,7 +385,6 @@ impl ProverParams {
 
     /// Obtain the parameters for anonymous to transparent.
     pub fn gen_abar_to_ar(
-        tree_depth: usize,
         address_format: AddressFormat,
     ) -> Result<ProverParams> {
         let label = match address_format {
@@ -418,7 +412,7 @@ impl ProverParams {
             uid: 0,
             amount: 0,
             asset_type: bls_zero,
-            path: MTPath::new(vec![node.clone(); tree_depth]),
+            path: MTPath::new(vec![node.clone(); TREE_DEPTH]),
             blind: bls_zero,
         };
         let (_, nullifier_trace) = nullify(
@@ -446,14 +440,11 @@ impl ProverParams {
         let pcs = load_srs_params(cs_size)?;
         let lagrange_pcs = load_lagrange_params(cs_size);
 
-        let verifier_params = if tree_depth == TREE_DEPTH {
+        let verifier_params =
             match VerifierParams::load_abar_to_ar(address_format).ok() {
                 Some(v) => Some(v.verifier_params),
                 None => None,
-            }
-        } else {
-            None
-        };
+            };
 
         let prover_params =
             indexer_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref(), verifier_params).unwrap();
@@ -549,7 +540,7 @@ impl VerifierParams {
         match Self::load_abar_to_bar(address_format) {
             Ok(vk) => Ok(vk),
             _ => {
-                let prover_params = ProverParams::gen_abar_to_bar(TREE_DEPTH, address_format)?;
+                let prover_params = ProverParams::gen_abar_to_bar( address_format)?;
                 Ok(VerifierParams::from(prover_params))
             }
         }
@@ -646,7 +637,7 @@ impl VerifierParams {
         match Self::load_abar_to_ar(address_format) {
             Ok(vk) => Ok(vk),
             _ => {
-                let prover_params = ProverParams::gen_abar_to_ar(TREE_DEPTH, address_format)?;
+                let prover_params = ProverParams::gen_abar_to_ar( address_format)?;
                 Ok(VerifierParams::from(prover_params))
             }
         }

--- a/api/src/parameters/params.rs
+++ b/api/src/parameters/params.rs
@@ -235,9 +235,7 @@ impl ProverParams {
     }
 
     /// Obtain the parameters for anonymous to confidential.
-    pub fn gen_abar_to_bar(
-        address_format: AddressFormat,
-    ) -> Result<ProverParams> {
+    pub fn gen_abar_to_bar(address_format: AddressFormat) -> Result<ProverParams> {
         let label = match address_format {
             SECP256K1 => String::from("abar_to_bar_secp256k1"),
             ED25519 => String::from("abar_to_bar_ed25519"),
@@ -320,9 +318,9 @@ impl ProverParams {
         let lagrange_pcs = load_lagrange_params(cs_size);
 
         let verifier_params = match VerifierParams::load_abar_to_bar(address_format).ok() {
-                Some(v) => Some(v.verifier_params),
-                None => None,
-            };
+            Some(v) => Some(v.verifier_params),
+            None => None,
+        };
 
         let prover_params =
             indexer_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref(), verifier_params).unwrap();
@@ -384,9 +382,7 @@ impl ProverParams {
     }
 
     /// Obtain the parameters for anonymous to transparent.
-    pub fn gen_abar_to_ar(
-        address_format: AddressFormat,
-    ) -> Result<ProverParams> {
+    pub fn gen_abar_to_ar(address_format: AddressFormat) -> Result<ProverParams> {
         let label = match address_format {
             SECP256K1 => String::from("abar_to_ar_secp256k1"),
             ED25519 => String::from("abar_to_ar_ed25519"),
@@ -440,11 +436,10 @@ impl ProverParams {
         let pcs = load_srs_params(cs_size)?;
         let lagrange_pcs = load_lagrange_params(cs_size);
 
-        let verifier_params =
-            match VerifierParams::load_abar_to_ar(address_format).ok() {
-                Some(v) => Some(v.verifier_params),
-                None => None,
-            };
+        let verifier_params = match VerifierParams::load_abar_to_ar(address_format).ok() {
+            Some(v) => Some(v.verifier_params),
+            None => None,
+        };
 
         let prover_params =
             indexer_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref(), verifier_params).unwrap();
@@ -540,7 +535,7 @@ impl VerifierParams {
         match Self::load_abar_to_bar(address_format) {
             Ok(vk) => Ok(vk),
             _ => {
-                let prover_params = ProverParams::gen_abar_to_bar( address_format)?;
+                let prover_params = ProverParams::gen_abar_to_bar(address_format)?;
                 Ok(VerifierParams::from(prover_params))
             }
         }
@@ -637,7 +632,7 @@ impl VerifierParams {
         match Self::load_abar_to_ar(address_format) {
             Ok(vk) => Ok(vk),
             _ => {
-                let prover_params = ProverParams::gen_abar_to_ar( address_format)?;
+                let prover_params = ProverParams::gen_abar_to_ar(address_format)?;
                 Ok(VerifierParams::from(prover_params))
             }
         }

--- a/api/src/parameters/setup.rs
+++ b/api/src/parameters/setup.rs
@@ -273,7 +273,7 @@ fn gen_ar_to_abar_vk(mut path: PathBuf) {
 fn gen_abar_to_ar_vk(path: PathBuf) {
     println!("Generating the verifying key for ABAR TO AR for secp256k1 ...");
     let mut new_path = path.clone();
-    let user_params = ProverParams::gen_abar_to_ar(TREE_DEPTH, SECP256K1).unwrap();
+    let user_params = ProverParams::gen_abar_to_ar(SECP256K1).unwrap();
     let node_params = VerifierParams::from(user_params);
     println!(
         "the size of the constraint system for ABAR TO AR for secp256k1: {}",
@@ -290,7 +290,7 @@ fn gen_abar_to_ar_vk(path: PathBuf) {
 
     println!("Generating the verifying key for ABAR TO AR for ed25519 ...");
     let mut new_path = path.clone();
-    let user_params = ProverParams::gen_abar_to_ar(TREE_DEPTH, ED25519).unwrap();
+    let user_params = ProverParams::gen_abar_to_ar(ED25519).unwrap();
     let node_params = VerifierParams::from(user_params);
     println!(
         "the size of the constraint system for ABAR TO AR for ed25519: {}",

--- a/api/src/parameters/setup.rs
+++ b/api/src/parameters/setup.rs
@@ -196,7 +196,7 @@ fn gen_transfer_vk(directory: PathBuf, address_format: AddressFormat) {
 fn gen_abar_to_bar_vk(path: PathBuf) {
     println!("Generating the verifying key for ABAR TO BAR for secp256k1 ...");
     let mut new_path = path.clone();
-    let user_params = ProverParams::gen_abar_to_bar(TREE_DEPTH, SECP256K1).unwrap();
+    let user_params = ProverParams::gen_abar_to_bar(SECP256K1).unwrap();
     let node_params = VerifierParams::from(user_params);
     println!(
         "the size of the constraint system for ABAR TO BAR for secp256k1: {}",
@@ -213,7 +213,7 @@ fn gen_abar_to_bar_vk(path: PathBuf) {
 
     println!("Generating the verifying key for ABAR TO BAR for ed25519 ...");
     let mut new_path = path.clone();
-    let user_params = ProverParams::gen_abar_to_bar(TREE_DEPTH, ED25519).unwrap();
+    let user_params = ProverParams::gen_abar_to_bar(ED25519).unwrap();
     let node_params = VerifierParams::from(user_params);
     println!(
         "the size of the constraint system for ABAR TO BAR for ed25519: {}",

--- a/smoke-tests/src/tests/smoke_axfr.rs
+++ b/smoke-tests/src/tests/smoke_axfr.rs
@@ -16,7 +16,7 @@ mod smoke_axfr {
                 AnonAssetRecord, MTLeafInfo, MTNode, MTPath, OpenAnonAssetRecord,
                 OpenAnonAssetRecordBuilder,
             },
-            FEE_TYPE, TREE_DEPTH,
+            FEE_TYPE,
         },
         keys::{KeyPair, KeyType, PublicKey},
         xfr::{

--- a/smoke-tests/src/tests/smoke_axfr.rs
+++ b/smoke-tests/src/tests/smoke_axfr.rs
@@ -362,7 +362,7 @@ mod smoke_axfr {
             SecretKey::Secp256k1(_) => SECP256K1,
         };
 
-        let params = ProverParams::gen_abar_to_bar(TREE_DEPTH, address_format).unwrap();
+        let params = ProverParams::gen_abar_to_bar(address_format).unwrap();
         let verify_params = VerifierParams::get_abar_to_bar(address_format).unwrap();
 
         let fdb = MemoryDB::new();

--- a/smoke-tests/src/tests/smoke_axfr.rs
+++ b/smoke-tests/src/tests/smoke_axfr.rs
@@ -249,7 +249,7 @@ mod smoke_axfr {
             SecretKey::Secp256k1(_) => SECP256K1,
         };
 
-        let params = ProverParams::gen_abar_to_ar(TREE_DEPTH, address_format).unwrap();
+        let params = ProverParams::gen_abar_to_ar(address_format).unwrap();
         let verify_params = VerifierParams::get_abar_to_ar(address_format).unwrap();
 
         let fdb = MemoryDB::new();

--- a/smoke-tests/src/tests/smoke_axfr_compatibility.rs
+++ b/smoke-tests/src/tests/smoke_axfr_compatibility.rs
@@ -456,7 +456,7 @@ mod smoke_axfr_compatibility {
             SecretKey::Secp256k1(_) => SECP256K1,
         };
 
-        let params = ProverParams::gen_abar_to_bar(TREE_DEPTH, address_format).unwrap();
+        let params = ProverParams::gen_abar_to_bar(address_format).unwrap();
         let verify_params = VerifierParams::get_abar_to_bar(address_format).unwrap();
         let receiver = if prng.gen() {
             KeyPair::sample(&mut prng, SECP256K1)

--- a/smoke-tests/src/tests/smoke_axfr_compatibility.rs
+++ b/smoke-tests/src/tests/smoke_axfr_compatibility.rs
@@ -309,7 +309,7 @@ mod smoke_axfr_compatibility {
         };
 
         let mut prng = test_rng();
-        let params = ProverParams::gen_abar_to_ar(TREE_DEPTH, address_format).unwrap();
+        let params = ProverParams::gen_abar_to_ar(address_format).unwrap();
         let verify_params = VerifierParams::get_abar_to_ar(address_format).unwrap();
         let receiver = if prng.gen() {
             KeyPair::sample(&mut prng, SECP256K1)

--- a/smoke-tests/src/tests/smoke_axfr_compatibility.rs
+++ b/smoke-tests/src/tests/smoke_axfr_compatibility.rs
@@ -25,7 +25,7 @@ mod smoke_axfr_compatibility {
                 AnonAssetRecord, AxfrOwnerMemo, MTLeafInfo, MTNode, MTPath, OpenAnonAssetRecord,
                 OpenAnonAssetRecordBuilder,
             },
-            FEE_TYPE, TREE_DEPTH,
+            FEE_TYPE,
         },
         keys::KeyPair,
         xfr::{

--- a/smoke-tests/src/tests/smoke_axfr_secp256k1_address.rs
+++ b/smoke-tests/src/tests/smoke_axfr_secp256k1_address.rs
@@ -225,7 +225,7 @@ mod smoke_axfr_secp256k1_address {
     #[test]
     fn abar_to_secp256k1() {
         let mut prng = test_rng();
-        let params = ProverParams::gen_abar_to_bar(TREE_DEPTH, SECP256K1).unwrap();
+        let params = ProverParams::gen_abar_to_bar(SECP256K1).unwrap();
         let verify_params = VerifierParams::get_abar_to_bar(SECP256K1).unwrap();
 
         let sender = KeyPair::sample(&mut prng, SECP256K1);

--- a/smoke-tests/src/tests/smoke_axfr_secp256k1_address.rs
+++ b/smoke-tests/src/tests/smoke_axfr_secp256k1_address.rs
@@ -177,7 +177,7 @@ mod smoke_axfr_secp256k1_address {
     #[test]
     fn abar_to_address() {
         let mut prng = test_rng();
-        let params = ProverParams::gen_abar_to_ar(TREE_DEPTH, SECP256K1).unwrap();
+        let params = ProverParams::gen_abar_to_ar(SECP256K1).unwrap();
         let verify_params = VerifierParams::get_abar_to_ar(SECP256K1).unwrap();
 
         let sender = KeyPair::sample(&mut prng, SECP256K1);

--- a/smoke-tests/src/tests/smoke_axfr_secp256k1_address.rs
+++ b/smoke-tests/src/tests/smoke_axfr_secp256k1_address.rs
@@ -14,7 +14,6 @@ mod smoke_axfr_secp256k1_address {
                 AnonAssetRecord, MTLeafInfo, MTNode, MTPath, OpenAnonAssetRecord,
                 OpenAnonAssetRecordBuilder,
             },
-            TREE_DEPTH,
         },
         keys::{KeyPair, PublicKey},
         xfr::{

--- a/smoke-tests/src/tests/smoke_axfr_wasm.rs
+++ b/smoke-tests/src/tests/smoke_axfr_wasm.rs
@@ -15,7 +15,7 @@ mod smoke_axfr_wasm {
                 AnonAssetRecord, MTLeafInfo, MTNode, MTPath, OpenAnonAssetRecord,
                 OpenAnonAssetRecordBuilder,
             },
-            FEE_TYPE, TREE_DEPTH,
+            FEE_TYPE,
         },
         keys::{KeyPair, PublicKey},
         xfr::{

--- a/smoke-tests/src/tests/smoke_axfr_wasm.rs
+++ b/smoke-tests/src/tests/smoke_axfr_wasm.rs
@@ -237,7 +237,7 @@ mod smoke_axfr_wasm {
     fn abar_to_bar(sender: KeyPair, receiver: KeyPair) {
         let seed: [u8; 32] = [0u8; 32];
         let mut prng = ChaChaRng::from_seed(seed);
-        let params = ProverParams::gen_abar_to_bar(TREE_DEPTH, SECP256K1).unwrap();
+        let params = ProverParams::gen_abar_to_bar(SECP256K1).unwrap();
         let verify_params = VerifierParams::get_abar_to_bar(SECP256K1).unwrap();
 
         let mut mt = EphemeralMerkleTree::new().unwrap();

--- a/smoke-tests/src/tests/smoke_axfr_wasm.rs
+++ b/smoke-tests/src/tests/smoke_axfr_wasm.rs
@@ -189,7 +189,7 @@ mod smoke_axfr_wasm {
     fn abar_to_ar(sender: KeyPair, receiver: KeyPair) {
         let seed: [u8; 32] = [0u8; 32];
         let mut prng = ChaChaRng::from_seed(seed);
-        let params = ProverParams::gen_abar_to_ar(TREE_DEPTH, SECP256K1).unwrap();
+        let params = ProverParams::gen_abar_to_ar(SECP256K1).unwrap();
         let verify_params = VerifierParams::get_abar_to_ar(SECP256K1).unwrap();
 
         let mut mt = EphemeralMerkleTree::new().unwrap();


### PR DESCRIPTION
* **The major changes of this PR**

Following the other changes, it makes sense to hardcode TREE_DEPTH.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

