### PR TITLE
Backtrace is now stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
       - uses: actions/cache@v3
         with:

--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -9,7 +9,6 @@ version = '0.4.0'
 authors = ['Findora <engineering@findora.org>']
 edition = '2021'
 description = 'Noah TurboPLONK protocol'
-build = "build.rs"
 
 [lib]
 name = 'noah_plonk'

--- a/plonk/build.rs
+++ b/plonk/build.rs
@@ -1,6 +1,0 @@
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    if rustc_version::version_meta().unwrap().channel == rustc_version::Channel::Nightly {
-        println!("cargo:rustc-cfg=nightly");
-    }
-}


### PR DESCRIPTION
* **The major changes of this PR**

Previously, when we use the backtrace feature, we have to use nightly. Now in 1.65.0, it becomes stable.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

