### PR TITLE
Implement std::error::Error for AccumulatorError 

### DIFF
--- a/accumulators/src/errors.rs
+++ b/accumulators/src/errors.rs
@@ -1,3 +1,4 @@
+use noah_algebra::error;
 use noah_algebra::prelude::AlgebraError;
 
 pub(crate) type Result<T> = core::result::Result<T, AccumulatorError>;
@@ -30,5 +31,12 @@ impl From<AlgebraError> for AccumulatorError {
 impl From<Box<dyn ruc::err::RucError>> for AccumulatorError {
     fn from(e: Box<dyn ruc::err::RucError>) -> AccumulatorError {
         AccumulatorError::Ruc(format!("{}", e))
+    }
+}
+
+impl error::Error for AccumulatorError {
+    #[cfg(feature = "std")]
+    fn description(&self) -> &str {
+        Box::leak(format!("{}", self).into_boxed_str())
     }
 }

--- a/algebra/src/lib.rs
+++ b/algebra/src/lib.rs
@@ -72,8 +72,8 @@ pub mod rand_helper;
 
 #[doc(hidden)]
 pub use ark_std::{
-    borrow, cfg_into_iter, cmp, collections, end_timer, fmt, hash, io, iter, marker, ops, rand,
-    result, start_timer, str, One, UniformRand, Zero,
+    borrow, cfg_into_iter, cmp, collections, end_timer, error, fmt, hash, io, iter, marker, ops,
+    rand, result, start_timer, str, One, UniformRand, Zero,
 };
 
 /// Implement serialization and deserialization


### PR DESCRIPTION
* **The major changes of this PR**

Necessary for the platform to use Ruc for error handling, here we implement std::error::Error for AccumulatorError.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

